### PR TITLE
feat: item limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,10 @@ Ephemerabot looks at the _tweeted_ value of each record to see if it has been tw
 To use the `tweetLatestEphemera()` function in debug mode:
 
 1. Make sure your connected Airtable base has at least one record with its _tweeted_ value set to `false`
-1. Navigate to _[server.js](https://github.com/dnywh/ephemerabot/blob/master/server.js)_ and find the `tweetLatestEphemera()` function
-1. Call `tweetLatestEphemera()` at the bottom of the script
-1. Run `npm start` only
-1. Keep an eye on your console for which tweets are queued for tweeting
-
-Comment-out `kickOffTweet(record, false)` if you just want to test in your terminal.
+2. Uncomment `tweetLatestEphemera()` in the _debugging_ section (at the bottom) of _[server.js](https://github.com/dnywh/ephemerabot/blob/master/server.js)_
+3. Uncomment `kickOffTweet(record, false)` (within the main `tweetLatestEphemera() function`) if you just want to debug locally
+4. Run `npm start`
+5. Keep an eye on your console for the results
 
 ### Running externally
 

--- a/server.js
+++ b/server.js
@@ -66,9 +66,8 @@ function tweetLatestEphemera(itemLimit = 6) {
             // Trim array to limit
             trimmedListTwoTweet = oldestToNewest.slice(0, itemLimit);
 
-            // Go through each item based on the 
-            // With a 20 second gap between each
-            // And tweet it out
+            // Go through the list of items (with a gap of 20 seconds),
+            // ...kicking off a tweet for each
             for (let i = 0; i < trimmedListTwoTweet.length; i++) {
                 (function (i) {
                     setTimeout(function () {
@@ -79,13 +78,13 @@ function tweetLatestEphemera(itemLimit = 6) {
                     }, 20000 * i);
                 })(i);
 
-                // Flick the 'tweeted' switch on to true now that tweet(s) sent
+                // Flick the 'tweeted' switch on to true now that tweet(s) have been kicked off
+                // Note that this assumes kickOffTweet() will succeed
                 trimmedListTwoTweet.map(i => {
                     i.fields.tweeted = true
                 })
 
-                // Updating base records
-                // Be careful editing this!
+                // Update Airtable base records accordingly
                 base('Main').update(trimmedListTwoTweet, function (err, records) {
                     if (err) throw err;
                 });


### PR DESCRIPTION
I've set limits to the amount of tweets that get sent out each morning and afternoon. This way I can batch upload ephemera (e.g. at the end of a big trip) and not have them all spew out on one afternoon.